### PR TITLE
[Update] Asking to add config file to gitignore

### DIFF
--- a/src/services/config-service.ts
+++ b/src/services/config-service.ts
@@ -4,10 +4,14 @@ import * as fs from 'fs'
 import * as vscode from 'vscode'
 import utils from '../utils/utils'
 
-const getCfgPath = () => path.join(vscode.workspace.rootPath as string, 'fastsfdc.json')
+const CONFIG_NAME = 'fastsfdc.json'
+
+const getCfgPath = () => path.join(vscode.workspace.rootPath as string, CONFIG_NAME)
 
 export default {
-  getConfigSync (): Config {
+  getConfigPath: getCfgPath,
+  getConfigFileName: () => { return CONFIG_NAME },
+  getConfigSync(): Config {
     const cfgPath = getCfgPath()
     if (!vscode.workspace.rootPath || !fs.existsSync(cfgPath)) {
       return { stored: false, credentials: [], currentCredential: 0 }


### PR DESCRIPTION
Credentials are stored within the fastsfdc.json config file.
The first time we add a credential we ask the user if he/she wants to update the gitignore to avoid tracking credentials on version control systems