### PR TITLE
[run-test] print code-coverage after test run. Printing only classes with coverage > 0

### DIFF
--- a/src/commands/run-test.ts
+++ b/src/commands/run-test.ts
@@ -3,7 +3,7 @@ import StatusBar from '../statusbar'
 import sfdcConnector from '../sfdc-connector'
 import logger, { diagnosticCollection } from '../logger'
 
-import { TestExecutionResult, TestResult } from '../fast-sfdc'
+import { TestExecutionResult, TestResult, CodeCoverage } from '../fast-sfdc'
 
 const lineString = 'line '
 const getStackTraceRange = (stackTrace: string, doc: vscode.TextDocument): vscode.Range => {
@@ -36,6 +36,12 @@ const printResults = (result: TestExecutionResult, document: vscode.TextDocument
   result.failures.forEach((v: TestResult) => {
     logger.appendLine(`${v.name}.${v.methodName} - KO: ${v.message}. ${v.stackTrace}`)
   })
+
+  logger.appendLine('*** Coverage ***')
+  result.codeCoverage.filter((v: CodeCoverage) => v.numLocationsNotCovered !== v.numLocations).forEach((v: CodeCoverage) => {
+    logger.appendLine(`${v.name}: ${Math.floor((v.numLocations - v.numLocationsNotCovered) / v.numLocations * 100)}%`)
+  })
+
   logger.show()
 
   updateProblemsPanel(result.failures, document)

--- a/src/fast-sfdc.d.ts
+++ b/src/fast-sfdc.d.ts
@@ -139,9 +139,16 @@ export interface TestResult {
   stackTrace: string;
 }
 
+export interface CodeCoverage {
+  name: string;
+  numLocations: number;
+  numLocationsNotCovered: number;
+}
+
 export interface TestExecutionResult {
   successes: TestResult[];
   failures: TestResult[];
+  codeCoverage: CodeCoverage[];
 }
 
 export type DoneCallback = (s: string) => void


### PR DESCRIPTION
I'm not sure it's so useful, but it gives you an idea of what the current test/s is/are covering