### PR TITLE
[create-metadata] automatically add new line in -meta.xml when storin…

### DIFF
--- a/src/commands/create-metadata.ts
+++ b/src/commands/create-metadata.ts
@@ -130,13 +130,19 @@ async function storeOnFileSystem (docBody: string, docBodyHtml: string, docMeta:
     await utils.writeFile(`${p.slice(0, -3)}.html`, docBodyHtml)
   }
   await utils.writeFile(p, docBody)
-  await utils.writeFile(`${p}-meta.xml`, buildXml({
+  let metaString = buildXml({
     [docType.toolingType.replace(/Member$/, '')]: {
       ...docMeta,
       apiVersion: docMeta.apiVersion + '.0',
       $: { xmlns: 'http://soap.sforce.com/2006/04/metadata' }
     }
-  }))
+  })
+
+  if (['ApexClassMember', 'ApexTriggerMember', 'ApexPageMember', 'ApexComponentMember', 'AuraDefinitionBundle'].includes(docType.toolingType)) {
+    metaString += '\n'
+  }
+
+  await utils.writeFile(`${p}-meta.xml`, metaString)
   const sfdcConnector = await packageService.getSfdcConnector()
   const metaPath = (
     isAuraBundle


### PR DESCRIPTION
Salesforce automatically adds a final newline to -meta.xml file of the following types:
- ApexClassMember
- ApexTriggerMember
- ApexPageMember
- ApexComponentMember
- AuraDefinitionBundle

Interestingly, Salesforce does not add a final newline to LightningComponentBundle.

This change is just for quality of life, to avoid diffs on -meta.xml files when retrieving metadata from Salesforce