### PR TITLE
ci: require quality checks for master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: quality
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - name: Lint and test
+        run: npm test
+      - name: Build production bundle
+        run: npm run package


### PR DESCRIPTION
## What changed

- add a single `quality` GitHub Actions check for pull requests and pushes to
  `master`
- run on Ubuntu 24.04 with Node.js 24
- install from the lockfile, run the complete lint/test suite, and build the
  production bundle
- cancel superseded runs for the same pull request
- do not run CI for tag pushes

## Why

Fast-Sfdc already prevented deletion and force-pushes on the default branch,
but it did not require pull requests or CI. This workflow provides one stable
required check without duplicating the six-platform release matrix.

## Validation

- `npm test` — 25 tests passed, including lint and type-check/build
- `npm run package` — production bundle completed
- `git diff --check`
