### PR TITLE
fix(release): make marketplace publishing retryable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,5 +77,16 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           for package in vsix/*.vsix; do
-            npx --yes @vscode/vsce@3.9.2 publish --packagePath "$package"
+            for attempt in 1 2 3; do
+              if npx --yes @vscode/vsce@3.9.2 publish --skip-duplicate --packagePath "$package"; then
+                break
+              fi
+
+              if [ "$attempt" -eq 3 ]; then
+                exit 1
+              fi
+
+              echo "Publish failed for $package (attempt $attempt/3); retrying in 15 seconds..."
+              sleep 15
+            done
           done


### PR DESCRIPTION
## Summary

- skip platform packages that already exist on the Visual Studio Marketplace
- retry transient Marketplace publishing failures up to three times
- keep a real failure after the final attempt

## Context

The v2.0.2 release successfully published darwin-arm64, then the Marketplace timed out while publishing darwin-x64. This makes the release job safe to resume without failing on the platform already published.