### PR TITLE
Feature: Apex Test Coverage Highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+### Fixed
+
+- Keep extension commands available while the new-version changelog notification is awaiting user interaction ([#60](https://github.com/micheletriaca/fast-sfdc/issues/60)).
+- Show Apex class and trigger test coverage with source-version checks.
+
 ## 2.0.2
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Unreleased
 
-### Fixed
+### Added
 
-- Keep extension commands available while the new-version changelog notification is awaiting user interaction ([#60](https://github.com/micheletriaca/fast-sfdc/issues/60)).
 - Show Apex class and trigger test coverage with source-version checks.
 
+### Fixed
+
+- Keep extension commands available while the new-version changelog notification
+  is awaiting user interaction ([#60](https://github.com/micheletriaca/fast-sfdc/issues/60)).
 
 ## 2.0.2
 

--- a/src/codelens-provider/codelens-run-test.ts
+++ b/src/codelens-provider/codelens-run-test.ts
@@ -30,11 +30,13 @@ export default class CodeLensRunTest implements vscode.CodeLensProvider {
       ))
     }
     if (!hasTestAnnotation) {
-      codeLens.push(new vscode.CodeLens(document.lineAt(0).range, {
-        command: 'FastSfdc.toggleTestCoverage',
-        title: 'Toggle test coverage',
-        arguments: [document]
-      }))
+      codeLens.push(new vscode.CodeLens(document.lineAt(0).range,
+        {
+          command: 'FastSfdc.toggleTestCoverage',
+          title: 'FastSfdc - Toggle test coverage highlighting',
+          arguments: [document]
+        }
+      ))
     }
     return codeLens
   }

--- a/src/codelens-provider/codelens-run-test.ts
+++ b/src/codelens-provider/codelens-run-test.ts
@@ -15,9 +15,11 @@ export default class CodeLensRunTest implements vscode.CodeLensProvider {
     const codeLens: vscode.CodeLens[] = []
     const docLine = document.lineCount
     const isTestToken = new RegExp('@isTest', 'i')
+    let hasTestAnnotation = false
     for (let i = 0; i < docLine - 1; i++) {
       const line = document.lineAt(i)
       if (!isTestToken.test(line.text)) continue
+      hasTestAnnotation = true
       const methodName = (codeLens.length > 0) ? getMethodName(document, i) : ''
       codeLens.push(new vscode.CodeLens(line.range,
         {
@@ -26,6 +28,13 @@ export default class CodeLensRunTest implements vscode.CodeLensProvider {
           arguments: [document, filename, methodName]
         }
       ))
+    }
+    if (!hasTestAnnotation) {
+      codeLens.push(new vscode.CodeLens(document.lineAt(0).range, {
+        command: 'FastSfdc.toggleTestCoverage',
+        title: 'Toggle test coverage',
+        arguments: [document]
+      }))
     }
     return codeLens
   }

--- a/src/codelens-provider/codelens-run-test.ts
+++ b/src/codelens-provider/codelens-run-test.ts
@@ -10,6 +10,7 @@ const getMethodName = (document: vscode.TextDocument, startingLine: number, coun
 
 export default class CodeLensRunTest implements vscode.CodeLensProvider {
   async provideCodeLenses (document: vscode.TextDocument): Promise<vscode.CodeLens[]> {
+    if (!parsers.isApexCoverageSupported(document.fileName)) return []
     const filename = parsers.getFilename(document.fileName)
 
     const codeLens: vscode.CodeLens[] = []

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -18,6 +18,7 @@ import retrieveSelectedMeta from './retrieve-selected-meta'
 import configureStaticResourceBundles from './static-resource-bundles'
 import runTest from './run-test'
 import generatePlugin from './generate-plugin'
+import toggleTestCoverage from './toggle-test-coverage'
 import { reporter } from '../logger'
 import { TextDocument, Uri } from 'vscode'
 import * as vscode from 'vscode'
@@ -95,6 +96,10 @@ export default {
   runTest: (document: vscode.TextDocument, className: string, methodName: string) => {
     reporter.sendEvent('runTest')
     runTest(document, className, methodName)
+  },
+  toggleTestCoverage: (document: vscode.TextDocument) => {
+    reporter.sendEvent('toggleTestCoverage')
+    toggleTestCoverage(document)
   },
   statusBarClick: () => {
     vscode.commands.executeCommand('FastSfdc.manageCredentials')

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -97,9 +97,14 @@ export default {
     reporter.sendEvent('runTest')
     runTest(document, className, methodName)
   },
-  toggleTestCoverage: (document: vscode.TextDocument) => {
+  toggleTestCoverage: async (document: vscode.TextDocument) => {
     reporter.sendEvent('toggleTestCoverage')
-    toggleTestCoverage(document)
+    try {
+      await toggleTestCoverage(document)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      await vscode.window.showErrorMessage(`Unable to show Apex test coverage: ${message}`)
+    }
   },
   statusBarClick: () => {
     vscode.commands.executeCommand('FastSfdc.manageCredentials')

--- a/src/commands/toggle-test-coverage.ts
+++ b/src/commands/toggle-test-coverage.ts
@@ -1,0 +1,68 @@
+import * as vscode from 'vscode'
+import sfdcConnector from '../sfdc-connector'
+import parsers from '../utils/parsers'
+import { getCoverageLines, ApexCoverageRecord } from '../utils/test-coverage'
+
+const coveredDecoration = vscode.window.createTextEditorDecorationType({
+  isWholeLine: true,
+  backgroundColor: new vscode.ThemeColor('testing.coveredBackground'),
+  overviewRulerColor: new vscode.ThemeColor('testing.iconPassed'),
+  overviewRulerLane: vscode.OverviewRulerLane.Left
+})
+const uncoveredDecoration = vscode.window.createTextEditorDecorationType({
+  isWholeLine: true,
+  backgroundColor: new vscode.ThemeColor('testing.uncoveredBackground'),
+  overviewRulerColor: new vscode.ThemeColor('testing.iconFailed'),
+  overviewRulerLane: vscode.OverviewRulerLane.Left
+})
+const enabledDocuments = new Set<string>()
+
+const getEditors = (document: vscode.TextDocument): vscode.TextEditor[] =>
+  vscode.window.visibleTextEditors.filter(editor => editor.document.uri.toString() === document.uri.toString())
+
+const clearCoverage = (document: vscode.TextDocument) => {
+  getEditors(document).forEach(editor => {
+    editor.setDecorations(coveredDecoration, [])
+    editor.setDecorations(uncoveredDecoration, [])
+  })
+  enabledDocuments.delete(document.uri.toString())
+}
+
+export const toggleTestCoverage = async (document: vscode.TextDocument): Promise<void> => {
+  const documentId = document.uri.toString()
+  if (enabledDocuments.has(documentId)) {
+    clearCoverage(document)
+    return
+  }
+
+  const className = parsers.getFilename(document.fileName)
+  const classes = await sfdcConnector.findApexClassesByNames([className])
+  const apexClass = classes.find(record => record.Name === className)
+  if (!apexClass) throw Error(`Apex class '${className}' was not found in the connected org`)
+
+  const records = await sfdcConnector.queryAll(`SELECT Coverage FROM ApexCodeCoverage WHERE ApexClassOrTriggerId = '${apexClass.Id}'`) as ApexCoverageRecord[]
+  if (records.length === 0) {
+    await vscode.window.showInformationMessage('No test classes have run to cover this Apex class.')
+    return
+  }
+  const { coveredLines, uncoveredLines } = getCoverageLines(records)
+  const coveredLineSet = new Set(coveredLines)
+  const coveredRanges = coveredLines
+    .filter(line => line <= document.lineCount)
+    .map(line => document.lineAt(line - 1).range)
+  const uncoveredRanges = uncoveredLines
+    .filter(line => !coveredLineSet.has(line) && line <= document.lineCount)
+    .map(line => document.lineAt(line - 1).range)
+  getEditors(document).forEach(editor => {
+    editor.setDecorations(coveredDecoration, coveredRanges)
+    editor.setDecorations(uncoveredDecoration, uncoveredRanges)
+  })
+  enabledDocuments.add(documentId)
+}
+
+export const disposeTestCoverage = () => {
+  coveredDecoration.dispose()
+  uncoveredDecoration.dispose()
+}
+
+export default toggleTestCoverage

--- a/src/commands/toggle-test-coverage.ts
+++ b/src/commands/toggle-test-coverage.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode'
 import sfdcConnector from '../sfdc-connector'
 import parsers from '../utils/parsers'
-import { getCoverageLines, ApexCoverageRecord } from '../utils/test-coverage'
+import { getCoverageLines, ApexCoverageRecord, sourcesMatch } from '../utils/test-coverage'
+import TestCoverageState, { TestCoverageLines } from '../utils/test-coverage-state'
 
 const coveredDecoration = vscode.window.createTextEditorDecorationType({
   isWholeLine: true,
@@ -15,54 +16,84 @@ const uncoveredDecoration = vscode.window.createTextEditorDecorationType({
   overviewRulerColor: new vscode.ThemeColor('testing.iconFailed'),
   overviewRulerLane: vscode.OverviewRulerLane.Left
 })
-const enabledDocuments = new Set<string>()
+const enabledDocuments = new TestCoverageState()
 
 const getEditors = (document: vscode.TextDocument): vscode.TextEditor[] =>
   vscode.window.visibleTextEditors.filter(editor => editor.document.uri.toString() === document.uri.toString())
+
+const getCoverageRanges = (document: vscode.TextDocument, lines: TestCoverageLines) => {
+  const coveredLineSet = new Set(lines.coveredLines)
+  return {
+    coveredRanges: lines.coveredLines
+      .filter(line => line <= document.lineCount)
+      .map(line => document.lineAt(line - 1).range),
+    uncoveredRanges: lines.uncoveredLines
+      .filter(line => !coveredLineSet.has(line) && line <= document.lineCount)
+      .map(line => document.lineAt(line - 1).range)
+  }
+}
+
+const applyCoverage = (editor: vscode.TextEditor, lines: TestCoverageLines) => {
+  const { coveredRanges, uncoveredRanges } = getCoverageRanges(editor.document, lines)
+  editor.setDecorations(coveredDecoration, coveredRanges)
+  editor.setDecorations(uncoveredDecoration, uncoveredRanges)
+}
 
 const clearCoverage = (document: vscode.TextDocument) => {
   getEditors(document).forEach(editor => {
     editor.setDecorations(coveredDecoration, [])
     editor.setDecorations(uncoveredDecoration, [])
   })
-  enabledDocuments.delete(document.uri.toString())
+  enabledDocuments.clear(document.uri.toString())
 }
 
 export const toggleTestCoverage = async (document: vscode.TextDocument): Promise<void> => {
+  if (!parsers.isApexCoverageSupported(document.fileName)) return
   const documentId = document.uri.toString()
   if (enabledDocuments.has(documentId)) {
     clearCoverage(document)
     return
   }
 
-  const className = parsers.getFilename(document.fileName)
-  const classes = await sfdcConnector.findApexClassesByNames([className])
-  const apexClass = classes.find(record => record.Name === className)
-  if (!apexClass) throw Error(`Apex class '${className}' was not found in the connected org`)
+  const apexName = parsers.getFilename(document.fileName)
+  const apexType = parsers.getApexCoverageType(document.fileName)
+  const records = apexType === 'ApexTrigger'
+    ? await sfdcConnector.findApexTriggersByNames([apexName])
+    : await sfdcConnector.findApexClassesByNames([apexName])
+  const apexClass = records.find(record => record.Name === apexName)
+  if (!apexClass) throw Error(`${apexType === 'ApexTrigger' ? 'Apex trigger' : 'Apex class'} '${apexName}' was not found in the connected org`)
 
-  const records = await sfdcConnector.queryAll(`SELECT Coverage FROM ApexCodeCoverage WHERE ApexClassOrTriggerId = '${apexClass.Id}'`) as ApexCoverageRecord[]
-  if (records.length === 0) {
+  if (!sourcesMatch(document.getText(), apexClass.Body)) {
+    const answer = await vscode.window.showWarningMessage(
+      'Local file differs from remote. Show covered lines anyway?',
+      'Yes', 'No'
+    )
+    if (answer !== 'Yes') return
+  }
+
+  const coverageRecords = await sfdcConnector.queryAll(`SELECT Coverage FROM ApexCodeCoverage WHERE ApexClassOrTriggerId = '${apexClass.Id}'`) as ApexCoverageRecord[]
+  if (coverageRecords.length === 0) {
     await vscode.window.showInformationMessage('No test classes have run to cover this Apex class.')
     return
   }
-  const { coveredLines, uncoveredLines } = getCoverageLines(records)
-  const coveredLineSet = new Set(coveredLines)
-  const coveredRanges = coveredLines
-    .filter(line => line <= document.lineCount)
-    .map(line => document.lineAt(line - 1).range)
-  const uncoveredRanges = uncoveredLines
-    .filter(line => !coveredLineSet.has(line) && line <= document.lineCount)
-    .map(line => document.lineAt(line - 1).range)
+  const { coveredLines, uncoveredLines } = getCoverageLines(coverageRecords)
+  const coverageLines = { coveredLines, uncoveredLines }
   getEditors(document).forEach(editor => {
-    editor.setDecorations(coveredDecoration, coveredRanges)
-    editor.setDecorations(uncoveredDecoration, uncoveredRanges)
+    applyCoverage(editor, coverageLines)
   })
-  enabledDocuments.add(documentId)
+  enabledDocuments.enable(documentId, coverageLines)
+}
+
+export const restoreTestCoverage = (editor: vscode.TextEditor) => {
+  const coverageLines = enabledDocuments.get(editor.document.uri.toString())
+  if (coverageLines) applyCoverage(editor, coverageLines)
 }
 
 export const disposeTestCoverage = () => {
   coveredDecoration.dispose()
   uncoveredDecoration.dispose()
 }
+
+export const clearTestCoverage = (document: vscode.TextDocument) => clearCoverage(document)
 
 export default toggleTestCoverage

--- a/src/commands/toggle-test-coverage.ts
+++ b/src/commands/toggle-test-coverage.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode'
+import StatusBar from '../statusbar'
 import sfdcConnector from '../sfdc-connector'
+import configService from '../services/config-service'
 import parsers from '../utils/parsers'
 import { getCoverageLines, ApexCoverageRecord, sourcesMatch } from '../utils/test-coverage'
 import TestCoverageState, { TestCoverageLines } from '../utils/test-coverage-state'
@@ -47,14 +49,7 @@ const clearCoverage = (document: vscode.TextDocument) => {
   enabledDocuments.clear(document.uri.toString())
 }
 
-export const toggleTestCoverage = async (document: vscode.TextDocument): Promise<void> => {
-  if (!parsers.isApexCoverageSupported(document.fileName)) return
-  const documentId = document.uri.toString()
-  if (enabledDocuments.has(documentId)) {
-    clearCoverage(document)
-    return
-  }
-
+const showTestCoverage = async (document: vscode.TextDocument, documentId: string): Promise<void> => {
   const apexName = parsers.getFilename(document.fileName)
   const apexType = parsers.getApexCoverageType(document.fileName)
   const records = apexType === 'ApexTrigger'
@@ -65,7 +60,7 @@ export const toggleTestCoverage = async (document: vscode.TextDocument): Promise
 
   if (!sourcesMatch(document.getText(), apexClass.Body)) {
     const answer = await vscode.window.showWarningMessage(
-      'Local file differs from remote. Show covered lines anyway?',
+      'Local source differs from the connected org. Coverage highlighting may be inaccurate. Show coverage anyway?',
       'Yes', 'No'
     )
     if (answer !== 'Yes') return
@@ -73,7 +68,7 @@ export const toggleTestCoverage = async (document: vscode.TextDocument): Promise
 
   const coverageRecords = await sfdcConnector.queryAll(`SELECT Coverage FROM ApexCodeCoverage WHERE ApexClassOrTriggerId = '${apexClass.Id}'`) as ApexCoverageRecord[]
   if (coverageRecords.length === 0) {
-    await vscode.window.showInformationMessage('No test classes have run to cover this Apex class.')
+    await vscode.window.showInformationMessage(`No test coverage is available for ${apexType === 'ApexTrigger' ? 'Apex trigger' : 'Apex class'} '${apexName}'. Run Apex tests in the connected org and try again.`)
     return
   }
   const { coveredLines, uncoveredLines } = getCoverageLines(coverageRecords)
@@ -82,6 +77,42 @@ export const toggleTestCoverage = async (document: vscode.TextDocument): Promise
     applyCoverage(editor, coverageLines)
   })
   enabledDocuments.enable(documentId, coverageLines)
+}
+
+const showTestCoverageWithStatus = (document: vscode.TextDocument, documentId: string): Promise<void> =>
+  new Promise((resolve, reject) => {
+    StatusBar.startLongJob(done => {
+      showTestCoverage(document, documentId).then(() => {
+        done('👍🏻')
+        resolve()
+      }, error => {
+        done('👎🏻')
+        reject(error)
+      })
+    })
+  })
+
+export const toggleTestCoverage = async (document: vscode.TextDocument): Promise<void> => {
+  if (!parsers.isApexCoverageSupported(document.fileName)) return
+  const documentId = document.uri.toString()
+  if (enabledDocuments.has(documentId)) {
+    clearCoverage(document)
+    return
+  }
+
+  const config = await configService.getConfig()
+  if (!config.credentials[config.currentCredential]) {
+    const answer = await vscode.window.showWarningMessage(
+      'Configure Salesforce credentials before viewing Apex test coverage.',
+      'Manage credentials'
+    )
+    if (answer === 'Manage credentials') {
+      await vscode.commands.executeCommand('FastSfdc.manageCredentials')
+    }
+    return
+  }
+
+  await showTestCoverageWithStatus(document, documentId)
 }
 
 export const restoreTestCoverage = (editor: vscode.TextEditor) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,7 @@ import CodeLensRunTest from './codelens-provider/codelens-run-test'
 import CodeLensFls from './codelens-provider/codelens-fls'
 import packageTreeView from './treeviews-prodiver/package-explorer'
 import * as vscode from 'vscode'
-import { disposeTestCoverage } from './commands/toggle-test-coverage'
+import { clearTestCoverage, disposeTestCoverage, restoreTestCoverage } from './commands/toggle-test-coverage'
 import open = require('open')
 
 const LAST_CHANGELOG_VERSION = 'fastSfdc.lastChangelogVersion'
@@ -71,6 +71,8 @@ export async function activate (ctx: ExtensionContext) {
   packageTreeView.attachTreeView(packageExplorerView)
   ctx.subscriptions.push(...[
     workspace.onDidChangeWorkspaceFolders(() => activateExtension(ctx)),
+    workspace.onDidCloseTextDocument(clearTestCoverage),
+    window.onDidChangeVisibleTextEditors(editors => editors.forEach(restoreTestCoverage)),
     workspace.onDidSaveTextDocument(textDocument => cmds.compile(textDocument)),
     commands.registerCommand('FastSfdc.compile', cmds.compile),
     commands.registerCommand('FastSfdc.convertToMetadataFormat', cmds.convertToMetadataFormat),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import CodeLensRunTest from './codelens-provider/codelens-run-test'
 import CodeLensFls from './codelens-provider/codelens-fls'
 import packageTreeView from './treeviews-prodiver/package-explorer'
 import * as vscode from 'vscode'
+import { disposeTestCoverage } from './commands/toggle-test-coverage'
 import open = require('open')
 
 const LAST_CHANGELOG_VERSION = 'fastSfdc.lastChangelogVersion'
@@ -96,6 +97,7 @@ export async function activate (ctx: ExtensionContext) {
     commands.registerCommand('FastSfdc.deploySelected', cmds.deploySelected),
     commands.registerCommand('FastSfdc.destroySelected', cmds.destroySelected),
     commands.registerCommand('FastSfdc.runTest', cmds.runTest),
+    commands.registerCommand('FastSfdc.toggleTestCoverage', cmds.toggleTestCoverage),
     commands.registerCommand('FastSfdc.initSfdy', cmds.initSfdy),
     commands.registerCommand('FastSfdc.editFlsProfiles', cmds.editFlsProfiles),
     commands.registerCommand('FastSfdc.generatePlugin', cmds.generatePlugin),
@@ -109,7 +111,8 @@ export async function activate (ctx: ExtensionContext) {
     commands.registerCommand('FastSfdc.refreshPackageTreeview', packageTreeView.refresh),
     commands.registerCommand('FastSfdc.filterPackageTreeview', packageTreeView.filter),
     commands.registerCommand('FastSfdc.showAllPackageTreeview', packageTreeView.filter),
-    packageExplorerView
+    packageExplorerView,
+    { dispose: disposeTestCoverage }
   ])
   await activateExtension(ctx)
 }

--- a/src/sfdc-connector/index.ts
+++ b/src/sfdc-connector/index.ts
@@ -239,6 +239,20 @@ const connector = {
     `)).records
   },
 
+  findApexTriggersByNames: async (triggerNames: string[]): Promise<ApexClassRecord[]> => {
+    if (!triggerNames.length) return []
+    const names = triggerNames.map(name => `'${name}'`).join(',')
+    return (await query(`SELECT
+      Id,
+      Name,
+      Body,
+      IsValid,
+      NamespacePrefix
+      FROM ApexTrigger
+      WHERE Name IN (${names})
+    `)).records
+  },
+
   executeAnonymous: async (scriptData: string) => {
     const result = await metadata('executeAnonymous', {
       String: scriptData

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -24,7 +24,9 @@ import { classifyOrganization } from '../services/org-protection'
 import { metadataRequiresTests, productionTestLevels } from '../services/deploy-test-options'
 import { cancellableDeployments, deploymentTimestamp } from '../services/deployment-cancellation'
 import { preserveNativePath } from '../utils/native-path'
-import { getCoverageLines } from '../utils/test-coverage'
+import { getCoverageLines, normalizeSource, sourcesMatch } from '../utils/test-coverage'
+import parsers from '../utils/parsers'
+import TestCoverageState from '../utils/test-coverage-state'
 
 const requireModule = createRequire(__filename)
 
@@ -46,6 +48,28 @@ suite('Extension Tests', function () {
       { Coverage: JSON.stringify({ coveredLines: [3, 1] }) },
       { Coverage: { coveredLines: [2, 3, 0], uncoveredLines: [4, 0] } }
     ]), { coveredLines: [1, 2, 3], uncoveredLines: [4] })
+  })
+
+  test('Supports coverage only for Apex classes and triggers', function () {
+    assert.strictEqual(parsers.isApexCoverageSupported('Example.cls'), true)
+    assert.strictEqual(parsers.isApexCoverageSupported('Example.trigger'), true)
+    assert.strictEqual(parsers.isApexCoverageSupported('Example.component'), false)
+    assert.strictEqual(parsers.getApexCoverageType('Example.trigger'), 'ApexTrigger')
+  })
+
+  test('Compares local and remote Apex source after normalizing line endings', function () {
+    assert.strictEqual(normalizeSource('line 1\r\nline 2\r'), 'line 1\nline 2\n')
+    assert.strictEqual(sourcesMatch('line 1\r\nline 2', 'line 1\nline 2'), true)
+    assert.strictEqual(sourcesMatch('line 1\nchanged', 'line 1\nline 2'), false)
+  })
+
+  test('Clears coverage state when an editor is reopened', function () {
+    const state = new TestCoverageState()
+    state.enable('file:///Example.cls', { coveredLines: [1], uncoveredLines: [2] })
+    assert.strictEqual(state.has('file:///Example.cls'), true)
+    assert.deepEqual(state.get('file:///Example.cls'), { coveredLines: [1], uncoveredLines: [2] })
+    state.clear('file:///Example.cls')
+    assert.strictEqual(state.has('file:///Example.cls'), false)
   })
 
   test('Preserves Windows UNC workspace roots', function () {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -24,6 +24,7 @@ import { classifyOrganization } from '../services/org-protection'
 import { metadataRequiresTests, productionTestLevels } from '../services/deploy-test-options'
 import { cancellableDeployments, deploymentTimestamp } from '../services/deployment-cancellation'
 import { preserveNativePath } from '../utils/native-path'
+import { getCoverageLines } from '../utils/test-coverage'
 
 const requireModule = createRequire(__filename)
 
@@ -38,6 +39,13 @@ suite('Extension Tests', function () {
   test('Something 1', function () {
     assert.equal(-1, [1, 2, 3].indexOf(5))
     assert.equal(-1, [1, 2, 3].indexOf(0))
+  })
+
+  test('Combines covered Apex lines from coverage records', function () {
+    assert.deepEqual(getCoverageLines([
+      { Coverage: JSON.stringify({ coveredLines: [3, 1] }) },
+      { Coverage: { coveredLines: [2, 3, 0], uncoveredLines: [4, 0] } }
+    ]), { coveredLines: [1, 2, 3], uncoveredLines: [4] })
   })
 
   test('Preserves Windows UNC workspace roots', function () {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -63,7 +63,7 @@ suite('Extension Tests', function () {
     assert.strictEqual(sourcesMatch('line 1\nchanged', 'line 1\nline 2'), false)
   })
 
-  test('Clears coverage state when an editor is reopened', function () {
+  test('Removes stored coverage lines when document state is cleared', function () {
     const state = new TestCoverageState()
     state.enable('file:///Example.cls', { coveredLines: [1], uncoveredLines: [2] })
     assert.strictEqual(state.has('file:///Example.cls'), true)

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -4,6 +4,16 @@ import * as nativePath from 'path'
 import { AuraDefType } from '../fast-sfdc'
 
 const parsers = {
+  isApexCoverageSupported (fullPath: string): boolean {
+    const normalizedPath = path.toUnix(fullPath)
+    const extension = normalizedPath.substring(normalizedPath.lastIndexOf('.')).toLowerCase()
+    return extension === '.cls' || extension === '.trigger'
+  },
+
+  getApexCoverageType (fullPath: string): 'ApexClass' | 'ApexTrigger' {
+    return path.toUnix(fullPath).toLowerCase().endsWith('.trigger') ? 'ApexTrigger' : 'ApexClass'
+  },
+
   getToolingType (document: vscode.TextDocument): string {
     const p = path.toUnix(document.fileName)
     const isAuraBundle = p.indexOf('/aura/') !== -1

--- a/src/utils/test-coverage-state.ts
+++ b/src/utils/test-coverage-state.ts
@@ -1,0 +1,24 @@
+export interface TestCoverageLines {
+  coveredLines: number[]
+  uncoveredLines: number[]
+}
+
+export default class TestCoverageState {
+  private readonly enabledDocuments = new Map<string, TestCoverageLines>()
+
+  has (documentId: string): boolean {
+    return this.enabledDocuments.has(documentId)
+  }
+
+  get (documentId: string): TestCoverageLines | undefined {
+    return this.enabledDocuments.get(documentId)
+  }
+
+  enable (documentId: string, lines: TestCoverageLines): void {
+    this.enabledDocuments.set(documentId, lines)
+  }
+
+  clear (documentId: string): void {
+    this.enabledDocuments.delete(documentId)
+  }
+}

--- a/src/utils/test-coverage.ts
+++ b/src/utils/test-coverage.ts
@@ -2,6 +2,11 @@ export interface ApexCoverageRecord {
   Coverage?: string | { coveredLines?: number[]; uncoveredLines?: number[] };
 }
 
+export const normalizeSource = (source: string): string => source.replace(/\r\n?/g, '\n')
+
+export const sourcesMatch = (localSource: string, remoteSource: string): boolean =>
+  normalizeSource(localSource) === normalizeSource(remoteSource)
+
 export const getCoverageLines = (records: ApexCoverageRecord[]): { coveredLines: number[]; uncoveredLines: number[] } => {
   const coveredLines = new Set<number>()
   const uncoveredLines = new Set<number>()

--- a/src/utils/test-coverage.ts
+++ b/src/utils/test-coverage.ts
@@ -1,0 +1,23 @@
+export interface ApexCoverageRecord {
+  Coverage?: string | { coveredLines?: number[]; uncoveredLines?: number[] };
+}
+
+export const getCoverageLines = (records: ApexCoverageRecord[]): { coveredLines: number[]; uncoveredLines: number[] } => {
+  const coveredLines = new Set<number>()
+  const uncoveredLines = new Set<number>()
+  records.forEach(record => {
+    const coverage = typeof record.Coverage === 'string'
+      ? JSON.parse(record.Coverage)
+      : record.Coverage
+    coverage?.coveredLines?.forEach((line: number) => {
+      if (Number.isInteger(line) && line > 0) coveredLines.add(line)
+    })
+    coverage?.uncoveredLines?.forEach((line: number) => {
+      if (Number.isInteger(line) && line > 0) uncoveredLines.add(line)
+    })
+  })
+  return {
+    coveredLines: [...coveredLines].sort((a, b) => a - b),
+    uncoveredLines: [...uncoveredLines].sort((a, b) => a - b)
+  }
+}


### PR DESCRIPTION
This feature inserts a new codelens button in an apex class that is NOT a test class, and allows to toggle apex test coverage highlighting :)

In action you will see this button:
<img width="363" height="92" alt="image" src="https://github.com/user-attachments/assets/9340c2c4-61e6-45a4-a391-991e4ebb95ee" />

When clicked it will toggle between highlighting the code lines that are covered:
<img width="1057" height="730" alt="image" src="https://github.com/user-attachments/assets/df5863ef-a46e-41dc-9bca-adb7293da648" />

If no test classes were run for an apex class, a notification will show up saying that the class is not covered
<img width="491" height="87" alt="image" src="https://github.com/user-attachments/assets/f980dd72-f47e-4a15-bd29-2852e2b84318" />

Note: no modifications have been made to the README files or the CHANGELOGS about this change
