### PR TITLE
fix(extension): keep activation responsive during changelog prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+### Fixed
+
+- Keep extension commands available while the new-version changelog notification
+  is awaiting user interaction ([#60](https://github.com/micheletriaca/fast-sfdc/issues/60)).
+
 ## 2.0.2
 
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import { commands, workspace, languages, window, ExtensionContext } from 'vscode
 import cmds from './commands'
 import statusBar from './statusbar'
 import configService from './services/config-service'
-import { initializeLogger, reporter } from './logger'
+import logger, { initializeLogger, reporter } from './logger'
 import CodeLensRunTest from './codelens-provider/codelens-run-test'
 import CodeLensFls from './codelens-provider/codelens-fls'
 import packageTreeView from './treeviews-prodiver/package-explorer'
@@ -49,7 +49,10 @@ const activateExtension = async (ctx: ExtensionContext) => {
     if (configService.consumeCredentialMigrationNotice()) {
       window.showInformationMessage('Fast-Sfdc credentials are now shared securely with the sfdy CLI.')
     }
-    await showChangelogForNewVersion(ctx)
+    showChangelogForNewVersion(ctx).catch(error => {
+      const message = error instanceof Error ? error.message : String(error)
+      logger.appendLine(`Unable to show the changelog notification: ${message}`)
+    })
   } else {
     statusBar.hideStatusBar()
     commands.executeCommand('setContext', 'fast-sfdc-active', false)


### PR DESCRIPTION
## Summary

- show the new-version changelog prompt without blocking extension activation
- log asynchronous prompt failures instead of leaving an unhandled rejection
- document the fix in the changelog

## Testing

- npm test

Closes #60