### PR TITLE
feat: validate and deploy from a diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,14 @@
         "title": "Fast-Sfdc: Deploy metadata"
       },
       {
+        "command": "FastSfdc.deployDiff",
+        "title": "Fast-Sfdc: Deploy git diff"
+      },
+      {
+        "command": "FastSfdc.validateDiff",
+        "title": "Fast-Sfdc: Validate git diff"
+      },
+      {
         "command": "FastSfdc.cancelDeploy",
         "title": "Fast-Sfdc: Cancel active deployment"
       },
@@ -259,6 +267,14 @@
         },
         {
           "command": "FastSfdc.deploy",
+          "when": "fast-sfdc-active && fast-sfdc-configured"
+        },
+        {
+          "command": "FastSfdc.deployDiff",
+          "when": "fast-sfdc-active && fast-sfdc-configured"
+        },
+        {
+          "command": "FastSfdc.validateDiff",
           "when": "fast-sfdc-active && fast-sfdc-configured"
         },
         {

--- a/src/commands/deploy-diff.ts
+++ b/src/commands/deploy-diff.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode'
+import { spawnSync } from 'child_process'
+import deploy from './deploy'
+import configService from '../services/config-service'
+import { resolveSourceLayout } from '../services/source-layout-service'
+import utils from '../utils/utils'
+
+const MAX_PREVIEWED_FILES = 20
+
+const git = (args: string[], cwd: string) => {
+  const res = spawnSync('git', args, { cwd })
+  if (res.error) throw Error(res.error.message)
+  if (res.status !== 0) throw Error(res.stderr.toString('utf8').trim() || `git ${args[0]} failed`)
+  return res.stdout.toString('utf8').trim()
+}
+
+const filePreview = (files: string[]) => {
+  const preview = files.slice(0, MAX_PREVIEWED_FILES).join('\n')
+  const remaining = files.length - MAX_PREVIEWED_FILES
+  return remaining > 0 ? `${preview}\n...and ${remaining} more` : preview
+}
+
+export default async function deployDiff (checkOnly = false) {
+  const rootFolder = utils.getWorkspaceFolder()
+
+  let branchName: string
+  try {
+    branchName = git(['branch', '--show-current'], rootFolder)
+  } catch (e) {
+    vscode.window.showErrorMessage(`Unable to read the current git branch: ${e.message}`)
+    return
+  }
+
+  const answer = await vscode.window.showInputBox({
+    ignoreFocusOut: true,
+    title: `${checkOnly ? 'Validate' : 'Deploy'} git diff on branch ${branchName || '(detached HEAD)'}`,
+    prompt: 'Diff is calculated between HEAD and the given number of commits behind',
+    placeHolder: 'How many commits behind?',
+    value: '1',
+    validateInput: value => /^[1-9]\d*$/.test(value.trim()) ? null : 'Enter a positive integer'
+  })
+  if (!answer) return
+
+  const diffCfg = `HEAD~${parseInt(answer.trim(), 10)}..HEAD`
+  const layout = resolveSourceLayout(rootFolder, configService.getSfdyConfigSync())
+  const srcPrefix = layout.relativeRoot.endsWith('/') ? layout.relativeRoot : layout.relativeRoot + '/'
+
+  let changedFiles: string[]
+  try {
+    changedFiles = git(['diff', '--name-only', '--diff-filter=d', diffCfg], rootFolder)
+      .split('\n')
+      .map(x => x.trim())
+      .filter(x => x.startsWith(srcPrefix))
+      .map(x => x.substring(srcPrefix.length))
+  } catch (e) {
+    vscode.window.showErrorMessage(`Unable to compute the git diff: ${e.message}`)
+    return
+  }
+
+  if (!changedFiles.length) {
+    vscode.window.showWarningMessage(`No changed files found in ${diffCfg} under ${layout.relativeRoot}`)
+    return
+  }
+
+  const confirmed = await vscode.window.showWarningMessage(
+    `${checkOnly ? 'Validate' : 'Deploy'} ${changedFiles.length} changed file(s) from ${diffCfg}?`,
+    {
+      modal: true,
+      detail: filePreview(changedFiles)
+    },
+    checkOnly ? 'Validate' : 'Deploy'
+  )
+  if (!confirmed) return
+
+  await deploy(checkOnly, false, [], diffCfg)
+}

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -34,7 +34,7 @@ const chooseProductionDeployMode = async (destructive: boolean): Promise<boolean
   return selected?.checkOnly
 }
 
-export default async function deploy (checkOnly = false, destructive = false, files: string[] = []) {
+export default async function deploy (checkOnly = false, destructive = false, files: string[] = [], diffCfg?: string) {
   let operation = checkOnly
     ? 'validate metadata'
     : destructive
@@ -94,7 +94,8 @@ export default async function deploy (checkOnly = false, destructive = false, fi
         testLevel: testSelection.testLevel,
         specifiedTests: testSelection.specifiedTests,
         config: sfdyConfig,
-        files: sanitizedFiles.length > 0 ? sanitizedFiles : undefined
+        files: sanitizedFiles.length > 0 ? sanitizedFiles : undefined,
+        diffCfg
       })
       const isDeployOk = deployResult.status === 'Succeeded'
       if (isDeployOk && !checkOnly && destructive) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,6 +7,7 @@ import createAuraDefinition from './create-aura-definition'
 import createMeta from './create-metadata'
 import credentials from './credentials'
 import deploy from './deploy'
+import deployDiff from './deploy-diff'
 import deploySelected from './deploy-selected'
 import destroySelected from './destroy-selected'
 import editFlsProfiles from './edit-fls-profiles'
@@ -63,6 +64,10 @@ export default {
   deploy: (checkOnly = false, destructive = false, files: string[] = []) => {
     reporter.sendEvent('deploy')
     deploy(checkOnly, destructive, files)
+  },
+  deployDiff: (checkOnly = false) => {
+    reporter.sendEvent('deployDiff')
+    deployDiff(checkOnly)
   },
   deploySelected: (uri: vscode.Uri, allUris: vscode.Uri[]) => {
     reporter.sendEvent('deploySelected')

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,6 +91,8 @@ export async function activate (ctx: ExtensionContext) {
     commands.registerCommand('FastSfdc.retrieveSelected', cmds.retrieveSelected),
     commands.registerCommand('FastSfdc.retrieveSelectedMeta', cmds.retrieveSelectedMeta),
     commands.registerCommand('FastSfdc.deploy', cmds.deploy),
+    commands.registerCommand('FastSfdc.deployDiff', () => cmds.deployDiff(false)),
+    commands.registerCommand('FastSfdc.validateDiff', () => cmds.deployDiff(true)),
     commands.registerCommand('FastSfdc.cancelDeploy', cmds.cancelDeploy),
     commands.registerCommand('FastSfdc.validate', () => cmds.deploy(true)),
     commands.registerCommand('FastSfdc.retrieveSingle', cmds.retrieveSelected),


### PR DESCRIPTION
## Deploy/validate the git diff of the last N commits

Adds two commands that deploy or validate only the metadata changed in the most recent commits, replacing an external shell script that wrapped the `sfdy` CLI.

### Commands

- `Fast-Sfdc: Deploy git diff` (`FastSfdc.deployDiff`)
- `Fast-Sfdc: Validate git diff` (`FastSfdc.validateDiff`)

### Flow

1. Reads the current git branch and shows it in the prompt.
2. Asks how many commits behind `HEAD` the diff should span (defaults to 1, positive integers only).
3. Computes `git diff --name-only --diff-filter=d HEAD~N..HEAD`, keeping only files under the resolved source folder, and aborts with a warning when nothing matches.
4. Shows a modal confirmation with a preview of the changed files (first 20, plus a count of the remaining ones).
5. Delegates to the existing deploy command, passing the range as the `diffCfg` option of `sfdy/deploy`.

<img width="606" height="82" alt="Screenshot 2026-09-04 at 18 14 37" src="https://github.com/user-attachments/assets/940cb7d5-0c3c-47e8-b59a-30de52d79472" />

<img width="610" height="111" alt="Screenshot 2026-09-04 at 18 14 43" src="https://github.com/user-attachments/assets/a92a55de-3ba7-40bc-935a-4a8064abc938" />

<img width="525" height="478" alt="Screenshot 2026-09-04 at 18 14 51" src="https://github.com/user-attachments/assets/e2f4a05f-c1a0-4d9c-ae3d-e03287acad69" />

